### PR TITLE
feat: add CmdOrCtrl modifier alias for cross-platform keybindings

### DIFF
--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -32,15 +32,15 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     assert.equal(normalizeKeystrokes('- '), false)
     assert.equal(normalizeKeystrokes('a '), false)
 
-describe "CmdOrCtrl modifier in .normalizeKeystrokes(keystrokes)", ->
-  cmdOrCtrl = if process.platform is 'darwin' then 'cmd' else 'ctrl'
+describe "cmdorctrl modifier in .normalizeKeystrokes(keystrokes)", ->
+  cmdorctrl = if process.platform is 'darwin' then 'cmd' else 'ctrl'
 
-  it "resolves CmdOrCtrl to cmd on darwin, ctrl on win32/linux", ->
-    assert.equal(normalizeKeystrokes('CmdOrCtrl-f'), "#{cmdOrCtrl}-f")
+  it "resolves cmdorctrl to cmd on darwin, ctrl on win32/linux", ->
+    assert.equal(normalizeKeystrokes('cmdorctrl-f'), "#{cmdorctrl}-f")
     # canonical order is ctrl < alt < shift < cmd, so ctrl precedes shift but shift precedes cmd
     expectedWithShift = if process.platform is 'darwin' then 'shift-cmd-F' else 'ctrl-shift-F'
-    assert.equal(normalizeKeystrokes('CmdOrCtrl-shift-f'), expectedWithShift)
-    assert.equal(normalizeKeystrokes('CmdOrCtrl-k CmdOrCtrl-d'), "#{cmdOrCtrl}-k #{cmdOrCtrl}-d")
+    assert.equal(normalizeKeystrokes('cmdorctrl-shift-f'), expectedWithShift)
+    assert.equal(normalizeKeystrokes('cmdorctrl-k cmdorctrl-d'), "#{cmdorctrl}-k #{cmdorctrl}-d")
 
 describe ".isModifierKeyup(keystroke)", ->
   it "returns true for single modifier keyups", ->

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -32,6 +32,14 @@ describe ".normalizeKeystrokes(keystrokes)", ->
     assert.equal(normalizeKeystrokes('- '), false)
     assert.equal(normalizeKeystrokes('a '), false)
 
+describe "CmdOrCtrl modifier in .normalizeKeystrokes(keystrokes)", ->
+  cmdOrCtrl = if process.platform is 'darwin' then 'cmd' else 'ctrl'
+
+  it "resolves CmdOrCtrl to cmd on darwin, ctrl on win32/linux", ->
+    assert.equal(normalizeKeystrokes('CmdOrCtrl-f'), "#{cmdOrCtrl}-f")
+    assert.equal(normalizeKeystrokes('CmdOrCtrl-shift-f'), "shift-#{cmdOrCtrl}-F")
+    assert.equal(normalizeKeystrokes('CmdOrCtrl-k CmdOrCtrl-d'), "#{cmdOrCtrl}-k #{cmdOrCtrl}-d")
+
 describe ".isModifierKeyup(keystroke)", ->
   it "returns true for single modifier keyups", ->
     assert.isTrue(isModifierKeyup('^ctrl'))

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -37,7 +37,9 @@ describe "CmdOrCtrl modifier in .normalizeKeystrokes(keystrokes)", ->
 
   it "resolves CmdOrCtrl to cmd on darwin, ctrl on win32/linux", ->
     assert.equal(normalizeKeystrokes('CmdOrCtrl-f'), "#{cmdOrCtrl}-f")
-    assert.equal(normalizeKeystrokes('CmdOrCtrl-shift-f'), "shift-#{cmdOrCtrl}-F")
+    # canonical order is ctrl < alt < shift < cmd, so ctrl precedes shift but shift precedes cmd
+    expectedWithShift = if process.platform is 'darwin' then 'shift-cmd-F' else 'ctrl-shift-F'
+    assert.equal(normalizeKeystrokes('CmdOrCtrl-shift-f'), expectedWithShift)
     assert.equal(normalizeKeystrokes('CmdOrCtrl-k CmdOrCtrl-d'), "#{cmdOrCtrl}-k #{cmdOrCtrl}-d")
 
 describe ".isModifierKeyup(keystroke)", ->

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -87,6 +87,8 @@ const slovakCmdCharactersForKeyCode = function(code, layout) {
 };
 
 exports.normalizeKeystrokes = function(keystrokes) {
+  const cmdOrCtrl = process.platform === 'darwin' ? 'cmd' : 'ctrl';
+  keystrokes = keystrokes.replace(/CmdOrCtrl/g, cmdOrCtrl);
   const normalizedKeystrokes = [];
   for (var keystroke of Array.from(keystrokes.split(WHITESPACE_REGEX))) {
     var normalizedKeystroke;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -87,8 +87,6 @@ const slovakCmdCharactersForKeyCode = function(code, layout) {
 };
 
 exports.normalizeKeystrokes = function(keystrokes) {
-  const cmdOrCtrl = process.platform === 'darwin' ? 'cmd' : 'ctrl';
-  keystrokes = keystrokes.replace(/CmdOrCtrl/g, cmdOrCtrl);
   const normalizedKeystrokes = [];
   for (var keystroke of Array.from(keystrokes.split(WHITESPACE_REGEX))) {
     var normalizedKeystroke;
@@ -114,6 +112,9 @@ var normalizeKeystroke = function(keystroke) {
 
   for (let i = 0; i < keys.length; i++) {
     var key = keys[i];
+    if (key === 'cmdorctrl') {
+      key = process.platform === 'darwin' ? 'cmd' : 'ctrl';
+    }
     if (MODIFIERS.has(key)) {
       modifiers.add(key);
     } else {


### PR DESCRIPTION
Adds CmdOrCtrl as a recognized modifier in normalizeKeystrokes(), resolving to cmd on macOS and ctrl on Windows/Linux. Follows the same convention as Electron's [Accelerator API](https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts). It will simplify keybindings in packages like [find-and-replace](https://github.com/pulsar-edit/pulsar/blob/master/packages/find-and-replace/keymaps/find-and-replace.cson) well. If this PR gains traction, I will improve keymap display in [command-palette](https://github.com/pulsar-edit/pulsar/tree/master/packages/command-palette) to show "Cmd" or "Ctrl" depending on platform.

I'm not sure what's name fit best to Pulsar schema. Other candidates like `cmdctrl` or `ctr_or_cmd` looks fine too.