### PR TITLE
Remove reference to old package in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,5 @@ window.addEventListener('core:move-down', (event) => console.log('down', event))
 
 The tests for this module *must* be run in Electron because they depend on browser APIs.
 
-* [`devtool`](https://github.com/Jam3/devtool) is bundled as a development dependency to run the tests.
-* Native modules need to be compiled against the version of Electron included with `devtool`. **Be sure to run `electron-rebuild` be sure recompile native dependencies before running tests.**
 * Tests can be run in batch mode with `npm test`
-* If you want to use the debugger, profiler, etc or just speed up your flow by being able to refresh the `devtool` window to re-run tests, use the `npm run test-drive` script. This will keep `devtool` open instead of exiting after the test run.
+* If you want to use the debugger, profiler, etc or just speed up your flow by being able to refresh the DevTools window to re-run tests, use the `npm run test-drive` script. This will keep the DevTools open instead of exiting after the test run.


### PR DESCRIPTION
The `devtools` package in question was removed as a development dependency long before it came into our custody and was taken out when moving to Electron 3:

https://github.com/pulsar-edit/atom-keymap/commit/28adf3e3aa6a668f141e84f781ff648f9ed503ff

Feel free to comment/suggest if what I've left isn't correct, I can't say I've tried to do much with the tests here before.
